### PR TITLE
Add canonical "if ! exists()" check around g:rainbow_levels definition

### DIFF
--- a/plugin/rainbow_levels.vim
+++ b/plugin/rainbow_levels.vim
@@ -1,12 +1,14 @@
-let g:rainbow_levels = [
-    \{'ctermfg': 2, 'guifg': 'green'  },
-    \{'ctermfg': 6, 'guifg': 'cyan'   },
-    \{'ctermfg': 4, 'guifg': 'blue'   },
-    \{'ctermfg': 5, 'guifg': 'magenta'},
-    \{'ctermfg': 1, 'guifg': 'red'    },
-    \{'ctermfg': 3, 'guifg': 'yellow' },
-    \{'ctermfg': 7, 'guifg': 'white'  },
-    \{'ctermfg': 0, 'guifg': 'gray'   }]
+if !exists('g:rainbow_levels')
+    let g:rainbow_levels = [
+        \{'ctermfg': 2, 'guifg': 'green'  },
+        \{'ctermfg': 6, 'guifg': 'cyan'   },
+        \{'ctermfg': 4, 'guifg': 'blue'   },
+        \{'ctermfg': 5, 'guifg': 'magenta'},
+        \{'ctermfg': 1, 'guifg': 'red'    },
+        \{'ctermfg': 3, 'guifg': 'yellow' },
+        \{'ctermfg': 7, 'guifg': 'white'  },
+        \{'ctermfg': 0, 'guifg': 'gray'   }]
+endif
 
 com! RainbowLevelsToggle call rainbow_levels#toggle()
 com! RainbowLevelsOn     call rainbow_levels#on()


### PR DESCRIPTION
This allows users to configure a different colorscheme in their .vimrc (as customary). As it stands, a separate after/plugin/rainbow_levels.vim (that is sourced after the plugin) would have to be used.