### PR TITLE
Keep search highlighting on top of the rainbow background

### DIFF
--- a/autoload/rainbow_levels.vim
+++ b/autoload/rainbow_levels.vim
@@ -47,7 +47,7 @@ endfunc
 func! rainbow_levels#match_level(level) abort
     let l:group   = 'RainbowLevel'.a:level
     let l:pattern = rainbow_levels#get_pattern(a:level) 
-    call add(w:rainbow_levels_match_ids, matchadd(l:group, l:pattern))
+    call add(w:rainbow_levels_match_ids, matchadd(l:group, l:pattern, -10))
 endfunc
 
 func! rainbow_levels#get_pattern(level) abort


### PR DESCRIPTION
The default priority of matchadd() is 10, which is higher than search highlighting (0). Supply a negative value (-10) so that rainbow highlighting is below search highlighting.