### PR TITLE
Fix softtabstop rendering

### DIFF
--- a/autoload/rainbow_levels.vim
+++ b/autoload/rainbow_levels.vim
@@ -51,7 +51,13 @@ func! rainbow_levels#match_level(level) abort
 endfunc
 
 func! rainbow_levels#get_pattern(level) abort
-    if rainbow_levels#is_indented_with_tabs()
+    if rainbow_levels#is_indented_with_softtabstop()
+        let l:size = a:level * rainbow_levels#get_indent_size()
+        let l:tab_level = l:size / &l:tabstop
+        let l:space_level = l:size % &l:tabstop
+
+        return '^\t\{'.l:tab_level.'} \{'.l:space_level.',}\S.*$'
+    elseif rainbow_levels#is_indented_with_tabs()
         return '^\t\{'.a:level.'}\ *\S.*$'
     else
         let l:start = a:level * rainbow_levels#get_indent_size()
@@ -69,4 +75,8 @@ endfunc
 
 func! rainbow_levels#is_indented_with_tabs() abort
     return &l:shiftwidth <= 0 || !&l:expandtab
+endfunc
+
+func! rainbow_levels#is_indented_with_softtabstop() abort
+    return &l:softtabstop > 0 && !&l:expandtab
 endfunc


### PR DESCRIPTION
Thank you for your attempt to fix #6 via #7. Unfortunately, the logic isn't quite that easy. So, I eventually get to implement this myself :-)

---

With soft tabstops, as much indent as possible is rendered with tabs, and the remainder with spaces. So, an indent of 5 x 4 = 20 is done via 2 * tab (16) + 4 * space, considering the `'tabstop'` and `'softtabstop'` values.

Add `rainbow_levels#is_indented_with_softtabstop()` and check that before `rainbow_levels#is_indented_with_tabs()` in `rainbow_levels#get_pattern()`.
