### PR TITLE
Correct issue with multiple indent levels that have the same color

### DIFF
--- a/autoload/rainbow_levels.vim
+++ b/autoload/rainbow_levels.vim
@@ -27,13 +27,16 @@ func! rainbow_levels#is_on() abort
 endfunc
 
 func! rainbow_levels#load_colors() abort
-    for l:color in g:rainbow_levels
-        exe rainbow_levels#get_highlight_command(l:color)
-    endfor
+    let l:color_index = 0
+    while l:color_index < len(g:rainbow_levels)
+        let l:color = g:rainbow_levels[l:color_index]
+        exe rainbow_levels#get_highlight_command(l:color, l:color_index)
+        let l:color_index += 1
+    endwhile
 endfunc
 
-func! rainbow_levels#get_highlight_command(color) abort
-    let l:command = 'hi RainbowLevel'.index(g:rainbow_levels, a:color)
+func! rainbow_levels#get_highlight_command(color, color_index) abort
+    let l:command = 'hi RainbowLevel'.a:color_index
 
     for l:property in ['ctermbg', 'ctermfg', 'guibg', 'guifg']
         if has_key(a:color, l:property)
@@ -46,7 +49,7 @@ endfunc
 
 func! rainbow_levels#match_level(level) abort
     let l:group   = 'RainbowLevel'.a:level
-    let l:pattern = rainbow_levels#get_pattern(a:level) 
+    let l:pattern = rainbow_levels#get_pattern(a:level)
     call add(w:rainbow_levels_match_ids, matchadd(l:group, l:pattern, -10))
 endfunc
 


### PR DESCRIPTION
Consider the following g:rainbow_levels:

let g:rainbow_levels = [
    \ {'ctermfg': 'red'},
    \ {'ctermfg': 'blue'},
    \ {'ctermfg': 'red'}]

Currently, this fails to apply red to both Level 1 and Level 3, since
get_highlight_command() uses index() to find the index of the color's
dictionary in g:rainbow_levels.  By replacing the for loop in
load_colors() with a while loop that keeps track of the index, the right
index for each indent level will be used, regardless of whether colors
are repeated or not.