### PR TITLE
Replace highlight_exists() with hlexists()

### DIFF
--- a/autoload/rainbow_levels.vim
+++ b/autoload/rainbow_levels.vim
@@ -20,7 +20,7 @@ func! rainbow_levels#on() abort
 	let w:rainbow_levels_match_ids = []
 	let l:level = 0
 
-	while highlight_exists('RainbowLevel'.l:level)
+	while hlexists('RainbowLevel'.l:level)
 		call rainbow_levels#match(l:level)
 		let l:level += 1
 	endwhile


### PR DESCRIPTION
Hi @thiagoalessio!

I really liked your plugin and out of curiosity I browsed through the code and noticed that you use `highlight_exists()` instead of its newer version `hlexists()` in `rainbow_levels#on()`. So I thought that maybe you'd like to know.

According to [`:h hlexists()`](http://vimhelp.appspot.com/eval.txt.html#hlexists%28%29), the function name `highlight_exists` is now obsolete, and it has been since Vim 5.2 which was released around the year 2000.

I've been using rainbow_level with this patch for a few days and I didn't notice any issue, also the tests are all validated. Its not a major change but I hope you'll find this PR useful.

Cheers,

